### PR TITLE
Symfony 5 Framework Bundle fix

### DIFF
--- a/src/Symfony/DependencyInjection/Configuration.php
+++ b/src/Symfony/DependencyInjection/Configuration.php
@@ -24,8 +24,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ruler');
+        $treeBuilder = new TreeBuilder('ruler');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
*  Construct TreeBuilder by passing root node information to constructor.